### PR TITLE
Enable Baseline Submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,15 @@ This repository aims to assist participants in understanding the following compo
 4. Leveraging zero knowledge machine learning (implicit in this Starter Kit)
 
 
-## For Developers:
 
-You may choose to create an example submission with a baseline model, or walkthrough a detailed version in our starter kit. 
 
-### To create an example submission
+## You may choose to submit our baseline model, or train your own model. 
+
+### To submit using our baseline model.
 Run the following commands in terminal after cloning the repository.
 
 We're providing you with this code snippet to help you gain a quick understanding of the submission workflow on Spectral. 
 
-For more details on individual steps, please read through the below Starter Kit.
 
 ```
 python3 -m venv env
@@ -54,11 +53,11 @@ spectral-cli configure
 ```
 You will be prompted to enter your API keys and Privy address. 
 ```
-python simple_submission.py
+python baseline_submission.py
 ```
 
 
-### Detaiiled walkthrough
+### To train your own model, follow the steps below.
 
 ### Prepare Your Environment
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ This repository aims to assist participants in understanding the following compo
 
 ## For Developers:
 
+You may choose to create an example submission with a baseline model, or walkthrough a detailed version in our starter kit. 
+
+### To create an example submission
+Run the following commands in terminal after cloning the repository.
+
+We're providing you with this code snippet to help you gain a quick understanding of the submission workflow on Spectral. 
+
+For more details on individual steps, please read through the below Starter Kit.
+
+```
+python3 -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+spectral-cli configure
+```
+You will be prompted to enter your API keys and Privy address. 
+```
+python simple_submission.py
+```
+
+
+### Detaiiled walkthrough
 
 ### Prepare Your Environment
 

--- a/baseline_submission.py
+++ b/baseline_submission.py
@@ -11,6 +11,7 @@ import json
 from tqdm.auto import tqdm
 from timeit import default_timer as timer
 import random
+import time
 import os
 import platform
 from spectral_datawrappers.credit_scoring.credit_scoring_wrapper import CreditScoringWrapper
@@ -61,7 +62,7 @@ def seed_worker():
     random.seed(worker_seed)
 
 
-def create_simple_submission():
+def create_baseline_submission():
     """
     This function will download the training data, train a model, and submit the predictions.
     This is to demonstrate how you can create an example submission using the Spectral CLI.
@@ -219,10 +220,10 @@ def create_simple_submission():
     json.dump(data, open('submissions/model_1_calibration.json', 'w'))
 
 
-    # Zane uncomment when ready to commit
-    # os.system("spectral-cli commit submissions/model_1.onnx submissions/model_1_calibration.json 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544")
+
+    os.system("spectral-cli commit submissions/model_1.onnx submissions/model_1_calibration.json 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544")
     print('Committed model, waiting 30 seconds for test set')
-    # time.sleep(30)
+    time.sleep(30)
 
     os.system("spectral-cli fetch-testing-data 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544")
 
@@ -279,8 +280,8 @@ def create_simple_submission():
     submission_dataframe.to_parquet('submissions/submission.parquet', index=False)
 
     print('Submitting predictions')
-    # Zane uncomment when ready to submit
-    # os.system("spectral-cli submit-inferences 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544 submissions/submission.parquet")
+
+    os.system("spectral-cli submit-inferences 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544 submissions/submission.parquet")
     print('submitted!')
 if __name__ == '__main__':
-    create_simple_submission()
+    create_baseline_submission()

--- a/helpers/modeling.py
+++ b/helpers/modeling.py
@@ -241,7 +241,8 @@ def train_step(model: torch.nn.Module,
                auc_pr_fn,
                ks_fn,
                prob_diff_fn,
-               device: torch.device = device):
+               device: torch.device = device,
+               simple_submission = False):
     """
     Training function for the model provided in the starter kit
     :param model:
@@ -300,7 +301,7 @@ def train_step(model: torch.nn.Module,
     train_ks /= len(data_loader)
     train_prob_diff /= len(data_loader)
 
-    if epochs % 5 == 0:
+    if epochs % 5 == 0 and not simple_submission:
         print(
             f'Training metrics:\nLoss: {train_loss:.5f} | Recall: {train_rec:.2f}% | F1-Score: {train_f1:.2f}% | AUROC: {train_auroc:.2f}% | Brier Score: {train_brier:.2f}% | AUC PR: {train_aucpr:.2f}% | KS-Statistic: {train_ks:.2f}% | Pred Prob Diff: {train_prob_diff:.2f}%')
     return {'loss': train_loss.item(),
@@ -325,7 +326,8 @@ def test_step(data_loader: torch.utils.data.DataLoader,
               auc_pr_fn,
               ks_fn,
               prob_diff_fn,
-              device: torch.device = device):
+              device: torch.device = device,
+              simple_submission = False):
     """
     Test step for the example model in the starter kit
     :param data_loader:
@@ -376,7 +378,7 @@ def test_step(data_loader: torch.utils.data.DataLoader,
         test_ks /= len(data_loader)
         test_prob_diff /= len(data_loader)
 
-        if epochs % 5 == 0:
+        if epochs % 5 == 0 and not simple_submission:
             print(
                 f'Testing metrics:\nLoss: {test_loss:.5f} | Recall: {test_rec:.2f}% | F1-Score: {test_f1:.2f}% | AUROC: {test_auroc:.2f}% | Brier Score: {test_brier:.2f}% | AUC PR: {test_aucpr:.2f}% | KS-Statistic: {test_ks:.2f}% | Pred Prob Diff: {test_prob_diff:.2f}%')
         return {'loss': test_loss.item(),

--- a/modeler_starter_kit.ipynb
+++ b/modeler_starter_kit.ipynb
@@ -44,8 +44,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:01.809274Z",
-     "start_time": "2023-12-13T16:31:42.904209Z"
+     "end_time": "2023-12-20T21:57:25.811452Z",
+     "start_time": "2023-12-20T21:57:22.524791Z"
     }
    },
    "outputs": [
@@ -53,7 +53,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100%|███████████████████████████████████████| 111M/111M [00:17<00:00, 6.49MiB/s]\r\n",
+      "100%|███████████████████████████████████████| 111M/111M [00:01<00:00, 76.0MiB/s]\r\n",
       "Training dataset successfully downloaded!\r\n"
      ]
     }
@@ -90,8 +90,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:01.904438Z",
-     "start_time": "2023-12-13T16:32:01.811125Z"
+     "end_time": "2023-12-20T21:57:25.874896Z",
+     "start_time": "2023-12-20T21:57:25.787215Z"
     }
    },
    "outputs": [
@@ -154,8 +154,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:02.468994Z",
-     "start_time": "2023-12-13T16:32:01.896065Z"
+     "end_time": "2023-12-20T21:57:27.342321Z",
+     "start_time": "2023-12-20T21:57:26.748442Z"
     }
    },
    "outputs": [
@@ -195,8 +195,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:02.496465Z",
-     "start_time": "2023-12-13T16:32:02.461713Z"
+     "end_time": "2023-12-20T21:57:27.869940Z",
+     "start_time": "2023-12-20T21:57:27.842353Z"
     }
    },
    "outputs": [
@@ -236,8 +236,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:03.080174Z",
-     "start_time": "2023-12-13T16:32:02.489307Z"
+     "end_time": "2023-12-20T21:57:29.041023Z",
+     "start_time": "2023-12-20T21:57:28.455095Z"
     }
    },
    "outputs": [
@@ -289,8 +289,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:03.371672Z",
-     "start_time": "2023-12-13T16:32:03.072422Z"
+     "end_time": "2023-12-20T21:57:30.103641Z",
+     "start_time": "2023-12-20T21:57:29.952453Z"
     }
    },
    "outputs": [
@@ -363,8 +363,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:04.000677Z",
-     "start_time": "2023-12-13T16:32:03.372075Z"
+     "end_time": "2023-12-20T21:57:32.206550Z",
+     "start_time": "2023-12-20T21:57:31.629665Z"
     }
    },
    "id": "fc2332c64291e0c7"
@@ -436,8 +436,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:05.547314Z",
-     "start_time": "2023-12-13T16:32:04.002302Z"
+     "end_time": "2023-12-20T21:57:35.861597Z",
+     "start_time": "2023-12-20T21:57:34.456817Z"
     }
    },
    "outputs": [],
@@ -499,8 +499,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.168979Z",
-     "start_time": "2023-12-13T16:32:05.549219Z"
+     "end_time": "2023-12-20T21:57:36.517002Z",
+     "start_time": "2023-12-20T21:57:35.857959Z"
     }
    },
    "id": "1e5ff04ee4140400"
@@ -512,8 +512,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.547612Z",
-     "start_time": "2023-12-13T16:32:06.172665Z"
+     "end_time": "2023-12-20T21:57:36.990198Z",
+     "start_time": "2023-12-20T21:57:36.508409Z"
     }
    },
    "outputs": [],
@@ -546,8 +546,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.578033Z",
-     "start_time": "2023-12-13T16:32:06.551399Z"
+     "end_time": "2023-12-20T21:57:36.994439Z",
+     "start_time": "2023-12-20T21:57:36.991586Z"
     }
    },
    "outputs": [],
@@ -566,8 +566,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.580898Z",
-     "start_time": "2023-12-13T16:32:06.573116Z"
+     "end_time": "2023-12-20T21:57:37.203201Z",
+     "start_time": "2023-12-20T21:57:37.190535Z"
     }
    },
    "outputs": [
@@ -575,7 +575,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dataloaders: (<torch.utils.data.dataloader.DataLoader object at 0x290595e90>, <torch.utils.data.dataloader.DataLoader object at 0x14a2ea9d0>)\n",
+      "Dataloaders: (<torch.utils.data.dataloader.DataLoader object at 0x29c740850>, <torch.utils.data.dataloader.DataLoader object at 0x29c6492d0>)\n",
       "Length of train dataloader: 101 batches of 3511\n",
       "Length of validation dataloader: 26 batches of 3511\n",
       "Using number of workers: 0\n"
@@ -612,8 +612,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.641462Z",
-     "start_time": "2023-12-13T16:32:06.579697Z"
+     "end_time": "2023-12-20T21:57:37.830695Z",
+     "start_time": "2023-12-20T21:57:37.775985Z"
     }
    },
    "outputs": [
@@ -639,8 +639,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.654382Z",
-     "start_time": "2023-12-13T16:32:06.633668Z"
+     "end_time": "2023-12-20T21:57:38.154149Z",
+     "start_time": "2023-12-20T21:57:38.131698Z"
     }
    },
    "outputs": [
@@ -666,8 +666,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.655598Z",
-     "start_time": "2023-12-13T16:32:06.649571Z"
+     "end_time": "2023-12-20T21:57:38.544188Z",
+     "start_time": "2023-12-20T21:57:38.533305Z"
     }
    },
    "outputs": [
@@ -703,8 +703,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.694082Z",
-     "start_time": "2023-12-13T16:32:06.652971Z"
+     "end_time": "2023-12-20T21:57:39.631692Z",
+     "start_time": "2023-12-20T21:57:39.622992Z"
     }
    },
    "outputs": [
@@ -752,8 +752,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:32:06.695928Z",
-     "start_time": "2023-12-13T16:32:06.656913Z"
+     "end_time": "2023-12-20T21:57:40.804509Z",
+     "start_time": "2023-12-20T21:57:40.779907Z"
     }
    },
    "outputs": [],
@@ -775,8 +775,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:33:35.739847Z",
-     "start_time": "2023-12-13T16:32:06.661250Z"
+     "end_time": "2023-12-20T21:59:09.914454Z",
+     "start_time": "2023-12-20T21:57:41.512484Z"
     }
    },
    "outputs": [
@@ -786,7 +786,7 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "962fa4390a754d20b16c64b3d2f51adf"
+       "model_id": "0a68f2d12e3345718617c2f56db09d10"
       }
      },
      "metadata": {},
@@ -832,7 +832,7 @@
       "Loss: 0.46522 | Recall: 58.16% | F1-Score: 67.71% | AUROC: 83.51% | Brier Score: 15.04% | AUC PR: 80.37% | KS-Statistic: 51.98% | Pred Prob Diff: 39.68%\n",
       "Validation metrics:\n",
       "Loss: 0.45662 | Recall: 60.20% | F1-Score: 69.26% | AUROC: 84.39% | Brier Score: 14.67% | AUC PR: 81.48% | KS-Statistic: 54.13% | Pred Prob Diff: 41.40%\n",
-      "Train time on cpu: 89.078 seconds\n"
+      "Train time on cpu: 88.400 seconds\n"
      ]
     }
    ],
@@ -916,8 +916,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:33:35.871799Z",
-     "start_time": "2023-12-13T16:33:35.739873Z"
+     "end_time": "2023-12-20T21:59:10.045604Z",
+     "start_time": "2023-12-20T21:59:09.914169Z"
     }
    },
    "outputs": [
@@ -942,8 +942,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:33:36.624116Z",
-     "start_time": "2023-12-13T16:33:35.928017Z"
+     "end_time": "2023-12-20T21:59:13.725717Z",
+     "start_time": "2023-12-20T21:59:13.027058Z"
     }
    },
    "outputs": [
@@ -995,8 +995,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:33:36.626562Z",
-     "start_time": "2023-12-13T16:33:36.623894Z"
+     "end_time": "2023-12-20T21:59:15.935426Z",
+     "start_time": "2023-12-20T21:59:15.926443Z"
     }
    },
    "outputs": [],
@@ -1014,8 +1014,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:33:36.665944Z",
-     "start_time": "2023-12-13T16:33:36.626723Z"
+     "end_time": "2023-12-20T21:59:17.169690Z",
+     "start_time": "2023-12-20T21:59:17.142763Z"
     }
    },
    "outputs": [],
@@ -1048,8 +1048,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:33:36.667368Z",
-     "start_time": "2023-12-13T16:33:36.645186Z"
+     "end_time": "2023-12-20T21:59:19.487556Z",
+     "start_time": "2023-12-20T21:59:19.474331Z"
     }
    },
    "outputs": [],
@@ -1151,8 +1151,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:34:15.683317Z",
-     "start_time": "2023-12-13T16:33:45.677322Z"
+     "end_time": "2023-12-20T21:59:54.715934Z",
+     "start_time": "2023-12-20T21:59:24.706202Z"
     }
    },
    "id": "a28c3eaf2b2062cb"
@@ -1176,7 +1176,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100%|███████████████████████████████████████| 424k/424k [00:00<00:00, 14.2MiB/s]\r\n",
+      "100%|███████████████████████████████████████| 424k/424k [00:00<00:00, 18.3MiB/s]\r\n",
       "Testing dataset successfully downloaded!\r\n"
      ]
     }
@@ -1187,8 +1187,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:34:18.760797Z",
-     "start_time": "2023-12-13T16:34:15.684670Z"
+     "end_time": "2023-12-20T22:00:05.049144Z",
+     "start_time": "2023-12-20T22:00:02.005248Z"
     }
    },
    "id": "e091d79fb8492212"
@@ -1215,8 +1215,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:34:18.814265Z",
-     "start_time": "2023-12-13T16:34:18.762131Z"
+     "end_time": "2023-12-20T22:00:05.088428Z",
+     "start_time": "2023-12-20T22:00:05.045002Z"
     }
    },
    "id": "fa6113393664f694"
@@ -1259,8 +1259,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:34:18.867470Z",
-     "start_time": "2023-12-13T16:34:18.815609Z"
+     "end_time": "2023-12-20T22:00:05.882068Z",
+     "start_time": "2023-12-20T22:00:05.756850Z"
     }
    },
    "id": "fb1dd60c6663bfe2"
@@ -1284,8 +1284,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:34:18.868751Z",
-     "start_time": "2023-12-13T16:34:18.861433Z"
+     "end_time": "2023-12-20T22:00:06.808753Z",
+     "start_time": "2023-12-20T22:00:06.801373Z"
     }
    },
    "id": "14aa507db8cdd04"
@@ -1302,8 +1302,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:34:18.970865Z",
-     "start_time": "2023-12-13T16:34:18.863710Z"
+     "end_time": "2023-12-20T22:00:07.318100Z",
+     "start_time": "2023-12-20T22:00:07.214805Z"
     }
    },
    "id": "4e4b14ce8da57dff"
@@ -1314,7 +1314,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "{'time_since_first_deposit': 38270476,\n 'market_max_drawdown_365d': -0.9929207900955996,\n 'market_macd': 103.61608597821805,\n 'time_since_last_liquidated': 999999999,\n 'market_natr': 2.6979461597724708,\n 'risk_factor_above_threshold_daily_count': 0,\n 'borrow_repay_diff_eth': 0.0041649690896,\n 'incoming_tx_count': 21,\n 'risky_first_tx_timestamp': 999999999,\n 'withdraw_deposit_diff_if_positive_eth': 0.0,\n 'risk_factor': 0.29732420841839474,\n 'total_balance_eth': 0.006086157934443,\n 'market_correl': 0.9636020036978413,\n 'net_incoming_tx_count': -5,\n 'deposit_amount_sum_eth': 0.009980238366,\n 'market_cci': 92.55880904342786,\n 'market_adxr': 39.95849243642371,\n 'avg_gas_paid_per_tx_eth': 0.0012606122140959544,\n 'market_rocr': 1.146113661152788,\n 'wallet_age': 38717049,\n 'market_macdsignal_macdfix': 81.56198182235475,\n 'market_adx': 42.488268568395355,\n 'market_aroonup': 92.85714285714286,\n 'market_rocp': 0.146113661152788,\n 'market_ht_trendmode': 1.0,\n 'risky_last_tx_timestamp': 999999999,\n 'liquidation_count': 0,\n 'min_eth_ever': 0.00422,\n 'market_dx': 58.07494078140641,\n 'borrow_amount_sum_eth': 0.0041649690896,\n 'liquidation_amount_sum_eth': 0.0,\n 'borrow_count': 1,\n 'total_gas_paid_eth': 0.03277591756649482,\n 'max_eth_ever': 0.20647,\n 'market_aroonosc': 64.44444444444444,\n 'deposit_count': 1,\n 'withdraw_amount_sum_eth': 0.0,\n 'market_atr': 62.36255215134959,\n 'repay_amount_sum_eth': 0.0,\n 'last_tx_timestamp': 1700542979,\n 'outgoing_tx_count': 26,\n 'max_risk_factor': 0.6108876677973348,\n 'total_collateral_avg_eth': 0.009971025179980712,\n 'avg_weighted_risk_factor': 0.0014265774149734112,\n 'risky_unique_contract_count': 0,\n 'unique_lending_protocol_count': 1,\n 'risky_tx_count': 0,\n 'risky_sum_outgoing_amount_eth': 0.0,\n 'market_fastk': 72.10239236036276,\n 'market_ppo': 5.100706157491268,\n 'market_plus_di': 30.878883702138104,\n 'repay_amount_avg_eth': 0.0,\n 'incoming_tx_sum_eth': 0.428267358479834,\n 'market_macd_macdfix': 98.45764392790716,\n 'total_available_borrows_eth': 0.005832209070127324,\n 'market_macdsignal': 85.82481616929248,\n 'outgoing_tx_avg_eth': 0.018971125544462397,\n 'first_tx_timestamp': 1663768211,\n 'market_linearreg_slope': 30.080727109804258,\n 'repay_count': 0,\n 'total_available_borrows_avg_eth': 0.004883336704314487,\n 'total_collateral_eth': 0.009999999999999998,\n 'outgoing_tx_sum_eth': 0.37942251088924794,\n 'market_cmo': 42.06885897740601,\n 'market_macd_macdext': 108.01392384064502,\n 'incoming_tx_avg_eth': 0.021413367923991698,\n 'unique_borrow_protocol_count': 1,\n 'market_macdsignal_macdext': 63.51484614967277,\n 'market_fastd': 76.22423020860309,\n 'risky_first_last_tx_timestamp_diff': 0,\n 'market_plus_dm': 328.90357242219267,\n 'avg_risk_factor': 0.40964953427427586,\n 'borrow_amount_avg_eth': 0.0041649690896,\n 'market_apo': 108.01392384064502,\n 'wallet_address': '0xc4be7dd2f1dbba2145fe59c26f757c788fc31c26'}"
+      "text/plain": "{'time_since_first_deposit': 38873846,\n 'market_max_drawdown_365d': -0.9929207900955996,\n 'market_macd': 49.47776989925342,\n 'time_since_last_liquidated': 999999999,\n 'market_natr': 3.034270494807834,\n 'risk_factor_above_threshold_daily_count': 0,\n 'borrow_repay_diff_eth': 0.0041649690896,\n 'incoming_tx_count': 21,\n 'risky_first_tx_timestamp': 999999999,\n 'withdraw_deposit_diff_if_positive_eth': 0.0,\n 'risk_factor': 0.2949190017127312,\n 'total_balance_eth': 0.006091293319269,\n 'market_correl': 0.9505535230377925,\n 'net_incoming_tx_count': -5,\n 'deposit_amount_sum_eth': 0.009980238366,\n 'market_cci': -113.56449928750611,\n 'market_adxr': 32.77005884171138,\n 'avg_gas_paid_per_tx_eth': 0.0012606122140959544,\n 'market_rocr': 0.9400277352084581,\n 'wallet_age': 39341397,\n 'market_macdsignal_macdfix': 65.43975184004066,\n 'market_adx': 30.201480724665846,\n 'market_aroonup': 35.714285714285715,\n 'market_rocp': -0.0599722647915419,\n 'market_ht_trendmode': 0.0,\n 'risky_last_tx_timestamp': 999999999,\n 'liquidation_count': 0,\n 'min_eth_ever': 0.00422,\n 'market_dx': 2.4380241584284343,\n 'borrow_amount_sum_eth': 0.0041649690896,\n 'liquidation_amount_sum_eth': 0.0,\n 'borrow_count': 1,\n 'total_gas_paid_eth': 0.03277591756649482,\n 'max_eth_ever': 0.20647,\n 'market_aroonosc': 64.44444444444444,\n 'deposit_count': 1,\n 'withdraw_amount_sum_eth': 0.0,\n 'market_atr': 65.4841269025119,\n 'repay_amount_sum_eth': 0.0,\n 'last_tx_timestamp': 1700542979,\n 'outgoing_tx_count': 26,\n 'max_risk_factor': 0.6108876677973348,\n 'total_collateral_avg_eth': 0.00997099232086717,\n 'avg_weighted_risk_factor': 0.001421707487876724,\n 'risky_unique_contract_count': 0,\n 'unique_lending_protocol_count': 1,\n 'risky_tx_count': 0,\n 'risky_sum_outgoing_amount_eth': 0.0,\n 'market_fastk': 45.93753391256965,\n 'market_ppo': 3.7827792919549554,\n 'market_plus_di': 20.781620972241367,\n 'repay_amount_avg_eth': 0.0,\n 'incoming_tx_sum_eth': 0.428267358479834,\n 'market_macd_macdfix': 47.45143204768601,\n 'total_available_borrows_eth': 0.0058521722857843295,\n 'market_macdsignal': 68.53080100760312,\n 'outgoing_tx_avg_eth': 0.018971125544462397,\n 'first_tx_timestamp': 1663768211,\n 'market_linearreg_slope': -8.692249742445055,\n 'repay_count': 0,\n 'total_available_borrows_avg_eth': 0.004889886575331577,\n 'total_collateral_eth': 0.009999999999999997,\n 'outgoing_tx_sum_eth': 0.37942251088924794,\n 'market_cmo': 6.522135966361225,\n 'market_macd_macdext': 82.84195024539258,\n 'incoming_tx_avg_eth': 0.021413367923991698,\n 'unique_borrow_protocol_count': 1,\n 'market_macdsignal_macdext': 110.23644063139919,\n 'market_fastd': 37.78064045257555,\n 'risky_first_last_tx_timestamp_diff': 0,\n 'market_plus_dm': 245.85145243407325,\n 'avg_risk_factor': 0.4088577290651778,\n 'borrow_amount_avg_eth': 0.0041649690896,\n 'market_apo': 82.84195024539258,\n 'wallet_address': '0xc4be7dd2f1dbba2145fe59c26f757c788fc31c26'}"
      },
      "execution_count": 30,
      "metadata": {},
@@ -1329,8 +1329,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:34:20.460442Z",
-     "start_time": "2023-12-13T16:34:18.971942Z"
+     "end_time": "2023-12-20T22:00:08.102266Z",
+     "start_time": "2023-12-20T22:00:07.761487Z"
     }
    },
    "id": "adba5ff58b4fc558"
@@ -1354,8 +1354,8 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "                               wallet_address  time_since_first_deposit  \\\n0  0xb27b86dc5e4d235c4d97fce0f87fe208dc572957                  49746444   \n1  0x587b938a8b21ea570325e91bdd01b161783a75e8                 114844686   \n2  0x769bbb304f5a9f1cbfcd1415cf6baadd4bafc3d3                  51012736   \n3  0xc0aab1c6f7d77d3a329e4dc25c430747d0cff2aa                  93793091   \n4  0xce2d7f4e80c3ed1942d53e8de406ef9b129f21e5                  41098338   \n\n   market_max_drawdown_365d  market_macd  time_since_last_liquidated  \\\n0                 -0.992921   103.616086                   999999999   \n1                 -0.992921   103.616086                   999999999   \n2                 -0.992921   103.616086                    41393913   \n3                 -0.992921   103.616086                   999999999   \n4                 -0.992921   103.616086                   999999999   \n\n   market_natr  risk_factor_above_threshold_daily_count  \\\n0     2.697946                                        0   \n1     2.697946                                       68   \n2     2.697946                                      546   \n3     2.697946                                      730   \n4     2.697946                                        0   \n\n   borrow_repay_diff_eth  incoming_tx_count  risky_first_tx_timestamp  ...  \\\n0               0.000006                 44                1652692299  ...   \n1              24.809797                233                1593532708  ...   \n2               0.000000                 41                1651426007  ...   \n3              39.419769                  9                1611712456  ...   \n4               0.000605                 23                1685221163  ...   \n\n   market_macd_macdext  incoming_tx_avg_eth  unique_borrow_protocol_count  \\\n0           108.013924             0.517186                             1   \n1           108.013924             3.489869                             2   \n2           108.013924             6.564009                             1   \n3           108.013924             3.291373                             2   \n4           108.013924             0.064724                             1   \n\n   market_macdsignal_macdext  market_fastd  \\\n0                  63.514846      76.22423   \n1                  63.514846      76.22423   \n2                  63.514846      76.22423   \n3                  63.514846      76.22423   \n4                  63.514846      76.22423   \n\n   risky_first_last_tx_timestamp_diff  market_plus_dm  avg_risk_factor  \\\n0                                   0      328.903572         0.009178   \n1                                   0      328.903572         0.294140   \n2                             9618823      328.903572         1.351261   \n3                            12491352      328.903572         0.881714   \n4                                   0      328.903572         0.378391   \n\n   borrow_amount_avg_eth  market_apo  \n0               0.000006  108.013924  \n1               1.757481  108.013924  \n2               1.123715  108.013924  \n3               2.425121  108.013924  \n4               0.000605  108.013924  \n\n[5 rows x 75 columns]",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>wallet_address</th>\n      <th>time_since_first_deposit</th>\n      <th>market_max_drawdown_365d</th>\n      <th>market_macd</th>\n      <th>time_since_last_liquidated</th>\n      <th>market_natr</th>\n      <th>risk_factor_above_threshold_daily_count</th>\n      <th>borrow_repay_diff_eth</th>\n      <th>incoming_tx_count</th>\n      <th>risky_first_tx_timestamp</th>\n      <th>...</th>\n      <th>market_macd_macdext</th>\n      <th>incoming_tx_avg_eth</th>\n      <th>unique_borrow_protocol_count</th>\n      <th>market_macdsignal_macdext</th>\n      <th>market_fastd</th>\n      <th>risky_first_last_tx_timestamp_diff</th>\n      <th>market_plus_dm</th>\n      <th>avg_risk_factor</th>\n      <th>borrow_amount_avg_eth</th>\n      <th>market_apo</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0xb27b86dc5e4d235c4d97fce0f87fe208dc572957</td>\n      <td>49746444</td>\n      <td>-0.992921</td>\n      <td>103.616086</td>\n      <td>999999999</td>\n      <td>2.697946</td>\n      <td>0</td>\n      <td>0.000006</td>\n      <td>44</td>\n      <td>1652692299</td>\n      <td>...</td>\n      <td>108.013924</td>\n      <td>0.517186</td>\n      <td>1</td>\n      <td>63.514846</td>\n      <td>76.22423</td>\n      <td>0</td>\n      <td>328.903572</td>\n      <td>0.009178</td>\n      <td>0.000006</td>\n      <td>108.013924</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0x587b938a8b21ea570325e91bdd01b161783a75e8</td>\n      <td>114844686</td>\n      <td>-0.992921</td>\n      <td>103.616086</td>\n      <td>999999999</td>\n      <td>2.697946</td>\n      <td>68</td>\n      <td>24.809797</td>\n      <td>233</td>\n      <td>1593532708</td>\n      <td>...</td>\n      <td>108.013924</td>\n      <td>3.489869</td>\n      <td>2</td>\n      <td>63.514846</td>\n      <td>76.22423</td>\n      <td>0</td>\n      <td>328.903572</td>\n      <td>0.294140</td>\n      <td>1.757481</td>\n      <td>108.013924</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0x769bbb304f5a9f1cbfcd1415cf6baadd4bafc3d3</td>\n      <td>51012736</td>\n      <td>-0.992921</td>\n      <td>103.616086</td>\n      <td>41393913</td>\n      <td>2.697946</td>\n      <td>546</td>\n      <td>0.000000</td>\n      <td>41</td>\n      <td>1651426007</td>\n      <td>...</td>\n      <td>108.013924</td>\n      <td>6.564009</td>\n      <td>1</td>\n      <td>63.514846</td>\n      <td>76.22423</td>\n      <td>9618823</td>\n      <td>328.903572</td>\n      <td>1.351261</td>\n      <td>1.123715</td>\n      <td>108.013924</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0xc0aab1c6f7d77d3a329e4dc25c430747d0cff2aa</td>\n      <td>93793091</td>\n      <td>-0.992921</td>\n      <td>103.616086</td>\n      <td>999999999</td>\n      <td>2.697946</td>\n      <td>730</td>\n      <td>39.419769</td>\n      <td>9</td>\n      <td>1611712456</td>\n      <td>...</td>\n      <td>108.013924</td>\n      <td>3.291373</td>\n      <td>2</td>\n      <td>63.514846</td>\n      <td>76.22423</td>\n      <td>12491352</td>\n      <td>328.903572</td>\n      <td>0.881714</td>\n      <td>2.425121</td>\n      <td>108.013924</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0xce2d7f4e80c3ed1942d53e8de406ef9b129f21e5</td>\n      <td>41098338</td>\n      <td>-0.992921</td>\n      <td>103.616086</td>\n      <td>999999999</td>\n      <td>2.697946</td>\n      <td>0</td>\n      <td>0.000605</td>\n      <td>23</td>\n      <td>1685221163</td>\n      <td>...</td>\n      <td>108.013924</td>\n      <td>0.064724</td>\n      <td>1</td>\n      <td>63.514846</td>\n      <td>76.22423</td>\n      <td>0</td>\n      <td>328.903572</td>\n      <td>0.378391</td>\n      <td>0.000605</td>\n      <td>108.013924</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 75 columns</p>\n</div>"
+      "text/plain": "                               wallet_address  time_since_first_deposit  \\\n0  0xc6fed6a9dd7b9c6e9ff2b0c5d88927fa522b6d3c                  53074718   \n1  0xf2c5ea12e7f6ea82bea1206b430c81bea90e1757                  64171072   \n2  0xbb480b4fde5ff1b286d64d2231874e6b58069a55                  68562782   \n3  0xb27b86dc5e4d235c4d97fce0f87fe208dc572957                  50349814   \n4  0xa4d9dbfc058a6a7fe0c5b36bc0a25eab4261f4c2                  82683400   \n\n   market_max_drawdown_365d  market_macd  time_since_last_liquidated  \\\n0                 -0.992921     49.47777                   999999999   \n1                 -0.992921     49.47777                    38088050   \n2                 -0.992921     49.47777                    48030495   \n3                 -0.992921     49.47777                   999999999   \n4                 -0.992921     49.47777                   999999999   \n\n   market_natr  risk_factor_above_threshold_daily_count  \\\n0      3.03427                                        0   \n1      3.03427                                      677   \n2      3.03427                                       35   \n3      3.03427                                        0   \n4      3.03427                                        0   \n\n   borrow_repay_diff_eth  incoming_tx_count  risky_first_tx_timestamp  ...  \\\n0               0.582885                 30                1652087201  ...   \n1               5.746085                  6                1638871041  ...   \n2               0.104275                  8                1632550188  ...   \n3               0.000006                 44                1652692299  ...   \n4               0.000000                 40                1618742934  ...   \n\n   market_macd_macdext  incoming_tx_avg_eth  unique_borrow_protocol_count  \\\n0             82.84195             1.866246                             1   \n1             82.84195             8.445984                             1   \n2             82.84195             0.069062                             1   \n3             82.84195             0.517186                             1   \n4             82.84195             2.297256                             1   \n\n   market_macdsignal_macdext  market_fastd  \\\n0                 110.236441      37.78064   \n1                 110.236441      37.78064   \n2                 110.236441      37.78064   \n3                 110.236441      37.78064   \n4                 110.236441      37.78064   \n\n   risky_first_last_tx_timestamp_diff  market_plus_dm  avg_risk_factor  \\\n0                            12264570      245.851452     1.930057e-01   \n1                            26083022      245.851452     1.094601e+04   \n2                            54224231      245.851452     8.852054e+05   \n3                                   0      245.851452     9.170240e-03   \n4                             3257488      245.851452     2.641758e-07   \n\n   borrow_amount_avg_eth  market_apo  \n0               1.033201    82.84195  \n1               5.746085    82.84195  \n2               0.104275    82.84195  \n3               0.000006    82.84195  \n4               0.107513    82.84195  \n\n[5 rows x 75 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>wallet_address</th>\n      <th>time_since_first_deposit</th>\n      <th>market_max_drawdown_365d</th>\n      <th>market_macd</th>\n      <th>time_since_last_liquidated</th>\n      <th>market_natr</th>\n      <th>risk_factor_above_threshold_daily_count</th>\n      <th>borrow_repay_diff_eth</th>\n      <th>incoming_tx_count</th>\n      <th>risky_first_tx_timestamp</th>\n      <th>...</th>\n      <th>market_macd_macdext</th>\n      <th>incoming_tx_avg_eth</th>\n      <th>unique_borrow_protocol_count</th>\n      <th>market_macdsignal_macdext</th>\n      <th>market_fastd</th>\n      <th>risky_first_last_tx_timestamp_diff</th>\n      <th>market_plus_dm</th>\n      <th>avg_risk_factor</th>\n      <th>borrow_amount_avg_eth</th>\n      <th>market_apo</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0xc6fed6a9dd7b9c6e9ff2b0c5d88927fa522b6d3c</td>\n      <td>53074718</td>\n      <td>-0.992921</td>\n      <td>49.47777</td>\n      <td>999999999</td>\n      <td>3.03427</td>\n      <td>0</td>\n      <td>0.582885</td>\n      <td>30</td>\n      <td>1652087201</td>\n      <td>...</td>\n      <td>82.84195</td>\n      <td>1.866246</td>\n      <td>1</td>\n      <td>110.236441</td>\n      <td>37.78064</td>\n      <td>12264570</td>\n      <td>245.851452</td>\n      <td>1.930057e-01</td>\n      <td>1.033201</td>\n      <td>82.84195</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0xf2c5ea12e7f6ea82bea1206b430c81bea90e1757</td>\n      <td>64171072</td>\n      <td>-0.992921</td>\n      <td>49.47777</td>\n      <td>38088050</td>\n      <td>3.03427</td>\n      <td>677</td>\n      <td>5.746085</td>\n      <td>6</td>\n      <td>1638871041</td>\n      <td>...</td>\n      <td>82.84195</td>\n      <td>8.445984</td>\n      <td>1</td>\n      <td>110.236441</td>\n      <td>37.78064</td>\n      <td>26083022</td>\n      <td>245.851452</td>\n      <td>1.094601e+04</td>\n      <td>5.746085</td>\n      <td>82.84195</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0xbb480b4fde5ff1b286d64d2231874e6b58069a55</td>\n      <td>68562782</td>\n      <td>-0.992921</td>\n      <td>49.47777</td>\n      <td>48030495</td>\n      <td>3.03427</td>\n      <td>35</td>\n      <td>0.104275</td>\n      <td>8</td>\n      <td>1632550188</td>\n      <td>...</td>\n      <td>82.84195</td>\n      <td>0.069062</td>\n      <td>1</td>\n      <td>110.236441</td>\n      <td>37.78064</td>\n      <td>54224231</td>\n      <td>245.851452</td>\n      <td>8.852054e+05</td>\n      <td>0.104275</td>\n      <td>82.84195</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0xb27b86dc5e4d235c4d97fce0f87fe208dc572957</td>\n      <td>50349814</td>\n      <td>-0.992921</td>\n      <td>49.47777</td>\n      <td>999999999</td>\n      <td>3.03427</td>\n      <td>0</td>\n      <td>0.000006</td>\n      <td>44</td>\n      <td>1652692299</td>\n      <td>...</td>\n      <td>82.84195</td>\n      <td>0.517186</td>\n      <td>1</td>\n      <td>110.236441</td>\n      <td>37.78064</td>\n      <td>0</td>\n      <td>245.851452</td>\n      <td>9.170240e-03</td>\n      <td>0.000006</td>\n      <td>82.84195</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0xa4d9dbfc058a6a7fe0c5b36bc0a25eab4261f4c2</td>\n      <td>82683400</td>\n      <td>-0.992921</td>\n      <td>49.47777</td>\n      <td>999999999</td>\n      <td>3.03427</td>\n      <td>0</td>\n      <td>0.000000</td>\n      <td>40</td>\n      <td>1618742934</td>\n      <td>...</td>\n      <td>82.84195</td>\n      <td>2.297256</td>\n      <td>1</td>\n      <td>110.236441</td>\n      <td>37.78064</td>\n      <td>3257488</td>\n      <td>245.851452</td>\n      <td>2.641758e-07</td>\n      <td>0.107513</td>\n      <td>82.84195</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 75 columns</p>\n</div>"
      },
      "execution_count": 31,
      "metadata": {},
@@ -1370,8 +1370,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:40:16.874714Z",
-     "start_time": "2023-12-13T16:34:20.465489Z"
+     "end_time": "2023-12-20T22:05:29.345553Z",
+     "start_time": "2023-12-20T22:00:09.987664Z"
     }
    },
    "id": "44694032677e1a7"
@@ -1393,15 +1393,15 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:40:16.892650Z",
-     "start_time": "2023-12-13T16:40:16.875839Z"
+     "end_time": "2023-12-20T22:05:29.365278Z",
+     "start_time": "2023-12-20T22:05:29.346955Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "   first_tx_timestamp  last_tx_timestamp  wallet_age  incoming_tx_count  \\\n0            1.039929           2.352751    0.707290          -0.316210   \n1           -0.724182           2.504105    2.772056          -0.234792   \n2            1.243630           1.658802    0.468873          -0.317502   \n3            0.331526           2.358672    1.536426          -0.331287   \n4            1.430284           2.437977    0.250407          -0.325256   \n\n   outgoing_tx_count  net_incoming_tx_count  total_gas_paid_eth  \\\n0          -0.069472               0.043354           -0.187372   \n1          -0.027704               0.008021           -0.115767   \n2          -0.073863               0.047688           -0.186324   \n3          -0.071940               0.044566           -0.139354   \n4          -0.075460               0.048643           -0.189269   \n\n   avg_gas_paid_per_tx_eth  risky_tx_count  risky_unique_contract_count  ...  \\\n0                -0.455988       -0.382633                    -0.484685  ...   \n1                -0.262286        0.528250                    11.281456  ...   \n2                -0.355406       -0.341800                     0.079445  ...   \n3                 0.875198       -0.363787                    -0.269779  ...   \n4                -0.445705       -0.382633                    -0.484685  ...   \n\n   market_natr  market_plus_di  market_plus_dm  market_ppo  market_rocp  \\\n0    -1.498255         0.81112       -0.034918    0.367723     0.604921   \n1    -1.498255         0.81112       -0.034918    0.367723     0.604921   \n2    -1.498255         0.81112       -0.034918    0.367723     0.604921   \n3    -1.498255         0.81112       -0.034918    0.367723     0.604921   \n4    -1.498255         0.81112       -0.034918    0.367723     0.604921   \n\n   market_rocr  unique_borrow_protocol_count  unique_lending_protocol_count  \\\n0     0.604921                      0.047380                      -0.505070   \n1     0.604921                      1.836817                       1.747295   \n2     0.604921                      0.047380                      -0.505070   \n3     0.604921                      1.836817                       1.747295   \n4     0.604921                      0.047380                      -0.505070   \n\n                               wallet_address  pred_prob  \n0  0xb27b86dc5e4d235c4d97fce0f87fe208dc572957   0.079843  \n1  0x587b938a8b21ea570325e91bdd01b161783a75e8   0.530819  \n2  0x769bbb304f5a9f1cbfcd1415cf6baadd4bafc3d3   0.989620  \n3  0xc0aab1c6f7d77d3a329e4dc25c430747d0cff2aa   0.567942  \n4  0xce2d7f4e80c3ed1942d53e8de406ef9b129f21e5   0.082619  \n\n[5 rows x 74 columns]",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>first_tx_timestamp</th>\n      <th>last_tx_timestamp</th>\n      <th>wallet_age</th>\n      <th>incoming_tx_count</th>\n      <th>outgoing_tx_count</th>\n      <th>net_incoming_tx_count</th>\n      <th>total_gas_paid_eth</th>\n      <th>avg_gas_paid_per_tx_eth</th>\n      <th>risky_tx_count</th>\n      <th>risky_unique_contract_count</th>\n      <th>...</th>\n      <th>market_natr</th>\n      <th>market_plus_di</th>\n      <th>market_plus_dm</th>\n      <th>market_ppo</th>\n      <th>market_rocp</th>\n      <th>market_rocr</th>\n      <th>unique_borrow_protocol_count</th>\n      <th>unique_lending_protocol_count</th>\n      <th>wallet_address</th>\n      <th>pred_prob</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1.039929</td>\n      <td>2.352751</td>\n      <td>0.707290</td>\n      <td>-0.316210</td>\n      <td>-0.069472</td>\n      <td>0.043354</td>\n      <td>-0.187372</td>\n      <td>-0.455988</td>\n      <td>-0.382633</td>\n      <td>-0.484685</td>\n      <td>...</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>0.047380</td>\n      <td>-0.505070</td>\n      <td>0xb27b86dc5e4d235c4d97fce0f87fe208dc572957</td>\n      <td>0.079843</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>-0.724182</td>\n      <td>2.504105</td>\n      <td>2.772056</td>\n      <td>-0.234792</td>\n      <td>-0.027704</td>\n      <td>0.008021</td>\n      <td>-0.115767</td>\n      <td>-0.262286</td>\n      <td>0.528250</td>\n      <td>11.281456</td>\n      <td>...</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>1.836817</td>\n      <td>1.747295</td>\n      <td>0x587b938a8b21ea570325e91bdd01b161783a75e8</td>\n      <td>0.530819</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>1.243630</td>\n      <td>1.658802</td>\n      <td>0.468873</td>\n      <td>-0.317502</td>\n      <td>-0.073863</td>\n      <td>0.047688</td>\n      <td>-0.186324</td>\n      <td>-0.355406</td>\n      <td>-0.341800</td>\n      <td>0.079445</td>\n      <td>...</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>0.047380</td>\n      <td>-0.505070</td>\n      <td>0x769bbb304f5a9f1cbfcd1415cf6baadd4bafc3d3</td>\n      <td>0.989620</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0.331526</td>\n      <td>2.358672</td>\n      <td>1.536426</td>\n      <td>-0.331287</td>\n      <td>-0.071940</td>\n      <td>0.044566</td>\n      <td>-0.139354</td>\n      <td>0.875198</td>\n      <td>-0.363787</td>\n      <td>-0.269779</td>\n      <td>...</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>1.836817</td>\n      <td>1.747295</td>\n      <td>0xc0aab1c6f7d77d3a329e4dc25c430747d0cff2aa</td>\n      <td>0.567942</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>1.430284</td>\n      <td>2.437977</td>\n      <td>0.250407</td>\n      <td>-0.325256</td>\n      <td>-0.075460</td>\n      <td>0.048643</td>\n      <td>-0.189269</td>\n      <td>-0.445705</td>\n      <td>-0.382633</td>\n      <td>-0.484685</td>\n      <td>...</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>0.047380</td>\n      <td>-0.505070</td>\n      <td>0xce2d7f4e80c3ed1942d53e8de406ef9b129f21e5</td>\n      <td>0.082619</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 74 columns</p>\n</div>"
+      "text/plain": "   first_tx_timestamp  last_tx_timestamp  wallet_age  incoming_tx_count  \\\n0            0.379634           2.453819    1.496452          -0.322241   \n1            0.119907           2.267982    1.800444          -0.332579   \n2            0.841503           2.088665    0.955868          -0.331718   \n3            1.039929           2.352751    0.723624          -0.316210   \n4           -1.712199           2.268076    3.944793          -0.317933   \n\n   outgoing_tx_count  net_incoming_tx_count  total_gas_paid_eth  \\\n0          -0.077057               0.050517           -0.189200   \n1          -0.077238               0.049819           -0.188563   \n2          -0.076113               0.048754           -0.188843   \n3          -0.069472               0.043354           -0.187372   \n4          -0.075133               0.048937           -0.185610   \n\n   avg_gas_paid_per_tx_eth  risky_tx_count  risky_unique_contract_count  ...  \\\n0                -0.340276       -0.373210                    -0.404095  ...   \n1                -0.196766       -0.351223                    -0.216052  ...   \n2                -0.389569       -0.373210                    -0.404095  ...   \n3                -0.455988       -0.382633                    -0.484685  ...   \n4                -0.250152       -0.360646                    -0.216052  ...   \n\n   market_natr  market_plus_di  market_plus_dm  market_ppo  market_rocp  \\\n0    -1.350833       -0.280356        -0.03885    0.209387     -0.55829   \n1    -1.350833       -0.280356        -0.03885    0.209387     -0.55829   \n2    -1.350833       -0.280356        -0.03885    0.209387     -0.55829   \n3    -1.350833       -0.280356        -0.03885    0.209387     -0.55829   \n4    -1.350833       -0.280356        -0.03885    0.209387     -0.55829   \n\n   market_rocr  unique_borrow_protocol_count  unique_lending_protocol_count  \\\n0     -0.55829                       0.04738                       -0.50507   \n1     -0.55829                       0.04738                       -0.50507   \n2     -0.55829                       0.04738                       -0.50507   \n3     -0.55829                       0.04738                       -0.50507   \n4     -0.55829                       0.04738                       -0.50507   \n\n                               wallet_address  pred_prob  \n0  0xc6fed6a9dd7b9c6e9ff2b0c5d88927fa522b6d3c   0.084403  \n1  0xf2c5ea12e7f6ea82bea1206b430c81bea90e1757   1.000000  \n2  0xbb480b4fde5ff1b286d64d2231874e6b58069a55   0.000000  \n3  0xb27b86dc5e4d235c4d97fce0f87fe208dc572957   0.086738  \n4  0xa4d9dbfc058a6a7fe0c5b36bc0a25eab4261f4c2   0.069166  \n\n[5 rows x 74 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>first_tx_timestamp</th>\n      <th>last_tx_timestamp</th>\n      <th>wallet_age</th>\n      <th>incoming_tx_count</th>\n      <th>outgoing_tx_count</th>\n      <th>net_incoming_tx_count</th>\n      <th>total_gas_paid_eth</th>\n      <th>avg_gas_paid_per_tx_eth</th>\n      <th>risky_tx_count</th>\n      <th>risky_unique_contract_count</th>\n      <th>...</th>\n      <th>market_natr</th>\n      <th>market_plus_di</th>\n      <th>market_plus_dm</th>\n      <th>market_ppo</th>\n      <th>market_rocp</th>\n      <th>market_rocr</th>\n      <th>unique_borrow_protocol_count</th>\n      <th>unique_lending_protocol_count</th>\n      <th>wallet_address</th>\n      <th>pred_prob</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0.379634</td>\n      <td>2.453819</td>\n      <td>1.496452</td>\n      <td>-0.322241</td>\n      <td>-0.077057</td>\n      <td>0.050517</td>\n      <td>-0.189200</td>\n      <td>-0.340276</td>\n      <td>-0.373210</td>\n      <td>-0.404095</td>\n      <td>...</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n      <td>0xc6fed6a9dd7b9c6e9ff2b0c5d88927fa522b6d3c</td>\n      <td>0.084403</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0.119907</td>\n      <td>2.267982</td>\n      <td>1.800444</td>\n      <td>-0.332579</td>\n      <td>-0.077238</td>\n      <td>0.049819</td>\n      <td>-0.188563</td>\n      <td>-0.196766</td>\n      <td>-0.351223</td>\n      <td>-0.216052</td>\n      <td>...</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n      <td>0xf2c5ea12e7f6ea82bea1206b430c81bea90e1757</td>\n      <td>1.000000</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0.841503</td>\n      <td>2.088665</td>\n      <td>0.955868</td>\n      <td>-0.331718</td>\n      <td>-0.076113</td>\n      <td>0.048754</td>\n      <td>-0.188843</td>\n      <td>-0.389569</td>\n      <td>-0.373210</td>\n      <td>-0.404095</td>\n      <td>...</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n      <td>0xbb480b4fde5ff1b286d64d2231874e6b58069a55</td>\n      <td>0.000000</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>1.039929</td>\n      <td>2.352751</td>\n      <td>0.723624</td>\n      <td>-0.316210</td>\n      <td>-0.069472</td>\n      <td>0.043354</td>\n      <td>-0.187372</td>\n      <td>-0.455988</td>\n      <td>-0.382633</td>\n      <td>-0.484685</td>\n      <td>...</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n      <td>0xb27b86dc5e4d235c4d97fce0f87fe208dc572957</td>\n      <td>0.086738</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>-1.712199</td>\n      <td>2.268076</td>\n      <td>3.944793</td>\n      <td>-0.317933</td>\n      <td>-0.075133</td>\n      <td>0.048937</td>\n      <td>-0.185610</td>\n      <td>-0.250152</td>\n      <td>-0.360646</td>\n      <td>-0.216052</td>\n      <td>...</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n      <td>0xa4d9dbfc058a6a7fe0c5b36bc0a25eab4261f4c2</td>\n      <td>0.069166</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 74 columns</p>\n</div>"
      },
      "execution_count": 32,
      "metadata": {},
@@ -1446,8 +1446,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:40:16.919064Z",
-     "start_time": "2023-12-13T16:40:16.896371Z"
+     "end_time": "2023-12-20T22:05:29.379302Z",
+     "start_time": "2023-12-20T22:05:29.367401Z"
     }
    },
    "outputs": [],
@@ -1475,8 +1475,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:40:16.942036Z",
-     "start_time": "2023-12-13T16:40:16.903956Z"
+     "end_time": "2023-12-20T22:05:29.410064Z",
+     "start_time": "2023-12-20T22:05:29.374012Z"
     }
    },
    "outputs": [],
@@ -1497,15 +1497,15 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:40:17.015236Z",
-     "start_time": "2023-12-13T16:40:16.906156Z"
+     "end_time": "2023-12-20T22:05:29.477813Z",
+     "start_time": "2023-12-20T22:05:29.376934Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                               wallet_address  pred_prob  pred_label  \\\n0  0xb27b86dc5e4d235c4d97fce0f87fe208dc572957   0.079843           0   \n1  0x587b938a8b21ea570325e91bdd01b161783a75e8   0.530819           0   \n2  0x769bbb304f5a9f1cbfcd1415cf6baadd4bafc3d3   0.989620           1   \n3  0xc0aab1c6f7d77d3a329e4dc25c430747d0cff2aa   0.567942           0   \n4  0xce2d7f4e80c3ed1942d53e8de406ef9b129f21e5   0.082619           0   \n\n   feature_1  feature_2  feature_3  feature_4  feature_5  feature_6  \\\n0   1.039929   2.352751   0.707290  -0.316210  -0.069472   0.043354   \n1  -0.724182   2.504105   2.772056  -0.234792  -0.027704   0.008021   \n2   1.243630   1.658802   0.468873  -0.317502  -0.073863   0.047688   \n3   0.331526   2.358672   1.536426  -0.331287  -0.071940   0.044566   \n4   1.430284   2.437977   0.250407  -0.325256  -0.075460   0.048643   \n\n   feature_7  ...  feature_63  feature_64  feature_65  feature_66  feature_67  \\\n0  -0.187372  ...    0.577065   -2.740575   -1.498255     0.81112   -0.034918   \n1  -0.115767  ...    0.577065   -2.740575   -1.498255     0.81112   -0.034918   \n2  -0.186324  ...    0.577065   -2.740575   -1.498255     0.81112   -0.034918   \n3  -0.139354  ...    0.577065   -2.740575   -1.498255     0.81112   -0.034918   \n4  -0.189269  ...    0.577065   -2.740575   -1.498255     0.81112   -0.034918   \n\n   feature_68  feature_69  feature_70  feature_71  feature_72  \n0    0.367723    0.604921    0.604921    0.047380   -0.505070  \n1    0.367723    0.604921    0.604921    1.836817    1.747295  \n2    0.367723    0.604921    0.604921    0.047380   -0.505070  \n3    0.367723    0.604921    0.604921    1.836817    1.747295  \n4    0.367723    0.604921    0.604921    0.047380   -0.505070  \n\n[5 rows x 75 columns]",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>wallet_address</th>\n      <th>pred_prob</th>\n      <th>pred_label</th>\n      <th>feature_1</th>\n      <th>feature_2</th>\n      <th>feature_3</th>\n      <th>feature_4</th>\n      <th>feature_5</th>\n      <th>feature_6</th>\n      <th>feature_7</th>\n      <th>...</th>\n      <th>feature_63</th>\n      <th>feature_64</th>\n      <th>feature_65</th>\n      <th>feature_66</th>\n      <th>feature_67</th>\n      <th>feature_68</th>\n      <th>feature_69</th>\n      <th>feature_70</th>\n      <th>feature_71</th>\n      <th>feature_72</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0xb27b86dc5e4d235c4d97fce0f87fe208dc572957</td>\n      <td>0.079843</td>\n      <td>0</td>\n      <td>1.039929</td>\n      <td>2.352751</td>\n      <td>0.707290</td>\n      <td>-0.316210</td>\n      <td>-0.069472</td>\n      <td>0.043354</td>\n      <td>-0.187372</td>\n      <td>...</td>\n      <td>0.577065</td>\n      <td>-2.740575</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>0.047380</td>\n      <td>-0.505070</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0x587b938a8b21ea570325e91bdd01b161783a75e8</td>\n      <td>0.530819</td>\n      <td>0</td>\n      <td>-0.724182</td>\n      <td>2.504105</td>\n      <td>2.772056</td>\n      <td>-0.234792</td>\n      <td>-0.027704</td>\n      <td>0.008021</td>\n      <td>-0.115767</td>\n      <td>...</td>\n      <td>0.577065</td>\n      <td>-2.740575</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>1.836817</td>\n      <td>1.747295</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0x769bbb304f5a9f1cbfcd1415cf6baadd4bafc3d3</td>\n      <td>0.989620</td>\n      <td>1</td>\n      <td>1.243630</td>\n      <td>1.658802</td>\n      <td>0.468873</td>\n      <td>-0.317502</td>\n      <td>-0.073863</td>\n      <td>0.047688</td>\n      <td>-0.186324</td>\n      <td>...</td>\n      <td>0.577065</td>\n      <td>-2.740575</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>0.047380</td>\n      <td>-0.505070</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0xc0aab1c6f7d77d3a329e4dc25c430747d0cff2aa</td>\n      <td>0.567942</td>\n      <td>0</td>\n      <td>0.331526</td>\n      <td>2.358672</td>\n      <td>1.536426</td>\n      <td>-0.331287</td>\n      <td>-0.071940</td>\n      <td>0.044566</td>\n      <td>-0.139354</td>\n      <td>...</td>\n      <td>0.577065</td>\n      <td>-2.740575</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>1.836817</td>\n      <td>1.747295</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0xce2d7f4e80c3ed1942d53e8de406ef9b129f21e5</td>\n      <td>0.082619</td>\n      <td>0</td>\n      <td>1.430284</td>\n      <td>2.437977</td>\n      <td>0.250407</td>\n      <td>-0.325256</td>\n      <td>-0.075460</td>\n      <td>0.048643</td>\n      <td>-0.189269</td>\n      <td>...</td>\n      <td>0.577065</td>\n      <td>-2.740575</td>\n      <td>-1.498255</td>\n      <td>0.81112</td>\n      <td>-0.034918</td>\n      <td>0.367723</td>\n      <td>0.604921</td>\n      <td>0.604921</td>\n      <td>0.047380</td>\n      <td>-0.505070</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 75 columns</p>\n</div>"
+      "text/plain": "                               wallet_address  pred_prob  pred_label  \\\n0  0xc6fed6a9dd7b9c6e9ff2b0c5d88927fa522b6d3c   0.084403           0   \n1  0xf2c5ea12e7f6ea82bea1206b430c81bea90e1757   1.000000           1   \n2  0xbb480b4fde5ff1b286d64d2231874e6b58069a55   0.000000           0   \n3  0xb27b86dc5e4d235c4d97fce0f87fe208dc572957   0.086738           0   \n4  0xa4d9dbfc058a6a7fe0c5b36bc0a25eab4261f4c2   0.069166           0   \n\n   feature_1  feature_2  feature_3  feature_4  feature_5  feature_6  \\\n0   0.379634   2.453819   1.496452  -0.322241  -0.077057   0.050517   \n1   0.119907   2.267982   1.800444  -0.332579  -0.077238   0.049819   \n2   0.841503   2.088665   0.955868  -0.331718  -0.076113   0.048754   \n3   1.039929   2.352751   0.723624  -0.316210  -0.069472   0.043354   \n4  -1.712199   2.268076   3.944793  -0.317933  -0.075133   0.048937   \n\n   feature_7  ...  feature_63  feature_64  feature_65  feature_66  feature_67  \\\n0  -0.189200  ...    0.416279   -2.740575   -1.350833   -0.280356    -0.03885   \n1  -0.188563  ...    0.416279   -2.740575   -1.350833   -0.280356    -0.03885   \n2  -0.188843  ...    0.416279   -2.740575   -1.350833   -0.280356    -0.03885   \n3  -0.187372  ...    0.416279   -2.740575   -1.350833   -0.280356    -0.03885   \n4  -0.185610  ...    0.416279   -2.740575   -1.350833   -0.280356    -0.03885   \n\n   feature_68  feature_69  feature_70  feature_71  feature_72  \n0    0.209387    -0.55829    -0.55829     0.04738    -0.50507  \n1    0.209387    -0.55829    -0.55829     0.04738    -0.50507  \n2    0.209387    -0.55829    -0.55829     0.04738    -0.50507  \n3    0.209387    -0.55829    -0.55829     0.04738    -0.50507  \n4    0.209387    -0.55829    -0.55829     0.04738    -0.50507  \n\n[5 rows x 75 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>wallet_address</th>\n      <th>pred_prob</th>\n      <th>pred_label</th>\n      <th>feature_1</th>\n      <th>feature_2</th>\n      <th>feature_3</th>\n      <th>feature_4</th>\n      <th>feature_5</th>\n      <th>feature_6</th>\n      <th>feature_7</th>\n      <th>...</th>\n      <th>feature_63</th>\n      <th>feature_64</th>\n      <th>feature_65</th>\n      <th>feature_66</th>\n      <th>feature_67</th>\n      <th>feature_68</th>\n      <th>feature_69</th>\n      <th>feature_70</th>\n      <th>feature_71</th>\n      <th>feature_72</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0xc6fed6a9dd7b9c6e9ff2b0c5d88927fa522b6d3c</td>\n      <td>0.084403</td>\n      <td>0</td>\n      <td>0.379634</td>\n      <td>2.453819</td>\n      <td>1.496452</td>\n      <td>-0.322241</td>\n      <td>-0.077057</td>\n      <td>0.050517</td>\n      <td>-0.189200</td>\n      <td>...</td>\n      <td>0.416279</td>\n      <td>-2.740575</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0xf2c5ea12e7f6ea82bea1206b430c81bea90e1757</td>\n      <td>1.000000</td>\n      <td>1</td>\n      <td>0.119907</td>\n      <td>2.267982</td>\n      <td>1.800444</td>\n      <td>-0.332579</td>\n      <td>-0.077238</td>\n      <td>0.049819</td>\n      <td>-0.188563</td>\n      <td>...</td>\n      <td>0.416279</td>\n      <td>-2.740575</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0xbb480b4fde5ff1b286d64d2231874e6b58069a55</td>\n      <td>0.000000</td>\n      <td>0</td>\n      <td>0.841503</td>\n      <td>2.088665</td>\n      <td>0.955868</td>\n      <td>-0.331718</td>\n      <td>-0.076113</td>\n      <td>0.048754</td>\n      <td>-0.188843</td>\n      <td>...</td>\n      <td>0.416279</td>\n      <td>-2.740575</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0xb27b86dc5e4d235c4d97fce0f87fe208dc572957</td>\n      <td>0.086738</td>\n      <td>0</td>\n      <td>1.039929</td>\n      <td>2.352751</td>\n      <td>0.723624</td>\n      <td>-0.316210</td>\n      <td>-0.069472</td>\n      <td>0.043354</td>\n      <td>-0.187372</td>\n      <td>...</td>\n      <td>0.416279</td>\n      <td>-2.740575</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0xa4d9dbfc058a6a7fe0c5b36bc0a25eab4261f4c2</td>\n      <td>0.069166</td>\n      <td>0</td>\n      <td>-1.712199</td>\n      <td>2.268076</td>\n      <td>3.944793</td>\n      <td>-0.317933</td>\n      <td>-0.075133</td>\n      <td>0.048937</td>\n      <td>-0.185610</td>\n      <td>...</td>\n      <td>0.416279</td>\n      <td>-2.740575</td>\n      <td>-1.350833</td>\n      <td>-0.280356</td>\n      <td>-0.03885</td>\n      <td>0.209387</td>\n      <td>-0.55829</td>\n      <td>-0.55829</td>\n      <td>0.04738</td>\n      <td>-0.50507</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 75 columns</p>\n</div>"
      },
      "execution_count": 35,
      "metadata": {},
@@ -1542,8 +1542,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-12-13T16:40:17.016385Z",
-     "start_time": "2023-12-13T16:40:16.945652Z"
+     "end_time": "2023-12-20T22:05:29.478848Z",
+     "start_time": "2023-12-20T22:05:29.413455Z"
     }
    },
    "id": "50d0a5dc5809c3a9"

--- a/modeler_starter_kit.ipynb
+++ b/modeler_starter_kit.ipynb
@@ -1253,7 +1253,8 @@
     "from spectral_datawrappers.credit_scoring.credit_scoring_wrapper import CreditScoringWrapper\n",
     "import pandas as pd\n",
     "import os\n",
-    "import configparser"
+    "import configparser\n",
+    "import platform"
    ],
    "metadata": {
     "collapsed": false,
@@ -1269,16 +1270,16 @@
    "execution_count": 28,
    "outputs": [],
    "source": [
-    "# Read your spectral api_key from your config file (Windows users see comments below)\n",
-    "config = configparser.ConfigParser()\n",
-    "config.read_file(open(os.path.expanduser(\"~/.spectral/config.ini\")))\n",
+    "# Read your Spectral api_key from your config file\n",
     "\n",
-    "# If you are using Windows the code above will not work.\n",
-    "# Comment out the lines above and use something like this instead:\n",
-    "# You should have a config.ini file within your .spectral folder in your home directory\n",
-    "# config = configparser.ConfigParser()\n",
-    "# config_path = os.path.join(os.environ['USERPROFILE'], '.spectral', 'config.ini')\n",
-    "# config.read(config_path)"
+    "# Macos and Linux users\n",
+    "if platform.system() != 'windows':\n",
+    "    config = configparser.ConfigParser()\n",
+    "    config.read_file(open(os.path.expanduser(\"~/.spectral/config.ini\")))\n",
+    "else:\n",
+    "    config = configparser.ConfigParser()\n",
+    "    config_path = os.path.join(os.environ['USERPROFILE'], '.spectral', 'config.ini')\n",
+    "    config.read(config_path)"
    ],
    "metadata": {
     "collapsed": false,

--- a/modeler_starter_kit.ipynb
+++ b/modeler_starter_kit.ipynb
@@ -1273,7 +1273,7 @@
     "# Read your Spectral api_key from your config file\n",
     "\n",
     "# Macos and Linux users\n",
-    "if platform.system() != 'windows':\n",
+    "if platform.system() != 'Windows':\n",
     "    config = configparser.ConfigParser()\n",
     "    config.read_file(open(os.path.expanduser(\"~/.spectral/config.ini\")))\n",
     "else:\n",

--- a/simple_submission.py
+++ b/simple_submission.py
@@ -231,7 +231,7 @@ def create_simple_submission():
 
     print('Fetching features for test set, this will take several minutes')
 
-    if platform.system() != 'windows':
+    if platform.system() != 'Windows':
         config = configparser.ConfigParser()
         config.read_file(open(os.path.expanduser("~/.spectral/config.ini")))
     else:

--- a/simple_submission.py
+++ b/simple_submission.py
@@ -1,0 +1,285 @@
+import duckdb
+import pandas as pd
+import numpy as np
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import train_test_split
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+import json
+from tqdm.auto import tqdm
+from timeit import default_timer as timer
+import random
+import os
+import platform
+from spectral_datawrappers.credit_scoring.credit_scoring_wrapper import CreditScoringWrapper
+import configparser
+from helpers.modeling import (TestData, TrainData, StratifiedBatchSampler,
+                              auc_fn, auroc_fn, auc_pr_fn,
+                              brier_fn, ks_fn, recall_fn, prob_diff_fn, f1_score_fn,
+                              train_step, test_step, eval_model,
+                              ValidationLossEarlyStopping)
+
+random_seed = 42
+np.random.seed(random_seed)
+torch.manual_seed(random_seed)
+torch.use_deterministic_algorithms(True, warn_only=True)
+torch.backends.cudnn.determenistic = True
+random.seed(random_seed)
+g = torch.Generator()
+g.manual_seed(random_seed)
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+os.environ["PYTHONHASHSEED"] = str(random_seed)
+
+
+
+class PredictLiquidationsV1(nn.Module):
+    """
+    The final layer should be a sigmoid, to get the probability of liquidation.
+    """
+
+    def __init__(self, input_features, output_features, hidden_units):
+        super().__init__()
+        self.linear_layer_stack = nn.Sequential(
+            nn.Linear(in_features=input_features, out_features=hidden_units),
+            nn.ReLU(),
+            nn.Dropout(p=0.2),
+            nn.Linear(in_features=hidden_units, out_features=hidden_units),
+            nn.ReLU(),
+            nn.Dropout(p=0.4),
+            nn.Linear(in_features=hidden_units, out_features=output_features),
+            nn.Sigmoid()
+        )
+
+    def forward(self, x):
+        return self.linear_layer_stack(x)
+
+def seed_worker():
+    worker_seed = random_seed
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)
+
+
+def create_simple_submission():
+    """
+    This function will download the training data, train a model, and submit the predictions.
+    This is to demonstrate how you can create an example submission using the Spectral CLI.
+    This will not result in a high score, but it will get you started.
+    We encourage you to walk through the starter kit notebook and improve upon these results.
+    """
+    # Download Training Data
+    print('Downloading training data')
+    os.system("spectral-cli fetch-training-data 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544")
+
+    training_dataframe = duckdb.query((f"""
+    select * from '{'0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544_training_data.parquet'}'
+    where max_risk_factor < 100
+    """)).df().drop(columns=['withdraw_amount_sum_eth'], inplace=False)
+
+
+    training_cols = list(training_dataframe.columns.drop(
+        ['borrow_timestamp', 'wallet_address', 'borrow_block_number', 'target',
+         'withdraw_deposit_diff_If_positive_eth']))\
+
+
+    # Split the data into training and validation sets
+    X_train, X_val, y_train, y_val = train_test_split(training_dataframe[training_cols].to_numpy(),
+                                                      training_dataframe['target'].to_numpy(),
+                                                      test_size=0.2,
+                                                      random_state=random_seed)
+
+    sc = StandardScaler()
+    X_train_scaled = sc.fit_transform(X_train)
+    X_val_scaled = sc.transform(X_val)
+
+    train_data = TrainData(torch.from_numpy(X_train_scaled).type(torch.float),
+                           torch.from_numpy(y_train).type(torch.float))
+
+    validation_data = TestData(torch.from_numpy(X_val_scaled).type(torch.float),
+                               torch.from_numpy(y_val).type(torch.float))
+
+    NUM_WORKERS = 0  # use all available CPU cores with os.cpu_count(), if possible
+    BATCH_SIZE = int(X_train.shape[0] / 100)  # ~1% of the training data
+
+    # initialize DataLoaders
+    train_dataloader = DataLoader(dataset=train_data,
+                                  batch_sampler=StratifiedBatchSampler(torch.tensor(y_train), batch_size=BATCH_SIZE),
+                                  worker_init_fn=seed_worker,
+                                  generator=g,
+                                  num_workers=NUM_WORKERS)
+    validation_dataloader = DataLoader(dataset=validation_data,
+                                       batch_size=BATCH_SIZE,
+                                       shuffle=False,
+                                       worker_init_fn=seed_worker,
+                                       generator=g,
+                                       num_workers=NUM_WORKERS)
+
+    train_features_batch, train_labels_batch = next(iter(train_dataloader))
+    validation_features_batch, validation_labels_batch = next(iter(validation_dataloader))
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    # instantiate the model
+    model_1 = PredictLiquidationsV1(input_features=X_train.shape[1],
+                                    output_features=1,
+                                    hidden_units=82).to(device)
+
+    # Initialize early stopping
+    early_stopper = ValidationLossEarlyStopping(patience=1, min_delta=0.0)
+
+    # Define loss function and optimizer
+    loss_fn = nn.BCELoss()
+    optimizer = optim.Adam(params=model_1.parameters(),
+                           lr=0.001,
+                           weight_decay=0.01)
+
+    # Measure training time
+    train_time_start = timer()
+
+    # Set the number of training epochs
+    # Note: You may want to increase the number of epochs for your final model
+    epochs = 5
+
+    # Create empty lists to track loss values
+    model_1_train_loss_values = []
+    model_1_validation_loss_values = []
+    model_1_epoch_count = []
+
+    # Training loop
+    print('Training model')
+    for epoch in tqdm(range(epochs)):
+        train_metrics = train_step(data_loader=train_dataloader,
+                                   model=model_1,
+                                   epochs=epoch,
+                                   loss_fn=loss_fn,
+                                   optimizer=optimizer,
+                                   auc_fn=auc_fn,
+                                   recall_fn=recall_fn,
+                                   f1_score_fn=f1_score_fn,
+                                   auroc_fn=auroc_fn,
+                                   brier_fn=brier_fn,
+                                   auc_pr_fn=auc_pr_fn,
+                                   ks_fn=ks_fn,
+                                   prob_diff_fn=prob_diff_fn,
+                                   simple_submission=True
+                                   )
+        validation_metrics = test_step(data_loader=validation_dataloader,
+                                       model=model_1,
+                                       epochs=epoch,
+                                       loss_fn=loss_fn,
+                                       auc_fn=auc_fn,
+                                       recall_fn=recall_fn,
+                                       f1_score_fn=f1_score_fn,
+                                       auroc_fn=auroc_fn,
+                                       brier_fn=brier_fn,
+                                       auc_pr_fn=auc_pr_fn,
+                                       ks_fn=ks_fn,
+                                       prob_diff_fn=prob_diff_fn,
+                                       simple_submission=True
+                                       )
+        model_1_epoch_count.append(epoch)
+        model_1_train_loss_values.append(train_metrics['loss'])
+        model_1_validation_loss_values.append(validation_metrics['loss'])
+
+        if early_stopper.early_stop_check(validation_metrics['loss']):
+            print(f"Stopped early at epoch: {epoch}")
+            break
+
+    # Calculate model 1 results
+    model_1_results = eval_model(model=model_1,
+                                 data_loader=validation_dataloader,
+                                 loss_fn=loss_fn,
+                                 auc_fn=auc_fn,
+                                 recall_fn=recall_fn,
+                                 f1_score_fn=f1_score_fn,
+                                 auroc_fn=auroc_fn,
+                                 brier_fn=brier_fn,
+                                 auc_pr_fn=auc_pr_fn,
+                                 ks_fn=ks_fn,
+                                 prob_diff_fn=prob_diff_fn,
+                                 device=device)
+    model_1_results.update({'model_name': model_1.__class__.__name__})
+
+    if not os.path.exists('submissions'):
+        os.makedirs('submissions')
+
+    # Export the ONNX file using the trained model and create an observation for model calibration.
+    model_1.eval()
+    torch.onnx.export(model_1,
+                      torch.randn((1, X_train.shape[1]), requires_grad=True).to(device),
+                      'submissions/model_1.onnx',
+                      input_names=['input'],
+                      output_names=['output'],
+                      dynamic_axes={'input': {0: 'batch_size'},
+                                    'output': {0: 'batch_size'}})
+
+    x = validation_features_batch[:1].reshape([-1]).numpy().tolist()
+    data = dict(input_data=[x])
+    json.dump(data, open('submissions/model_1_calibration.json', 'w'))
+
+
+    # Zane uncomment when ready to commit
+    # os.system("spectral-cli commit submissions/model_1.onnx submissions/model_1_calibration.json 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544")
+    print('Committed model, waiting 30 seconds for test set')
+    # time.sleep(30)
+
+    os.system("spectral-cli fetch-testing-data 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544")
+
+    test_set_addresses = pd.read_parquet('0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544_testing_dataset.parquet')[
+        'wallet_address'].tolist()
+
+    print('Fetching features for test set, this will take several minutes')
+
+    if platform.system() != 'windows':
+        config = configparser.ConfigParser()
+        config.read_file(open(os.path.expanduser("~/.spectral/config.ini")))
+    else:
+        config = configparser.ConfigParser()
+        config_path = os.path.join(os.environ['USERPROFILE'], '.spectral', 'config.ini')
+        config.read(config_path)
+
+    # Read our key and set a client
+    spectral_api_key = config['global']['spectral_api_key']
+    client = CreditScoringWrapper({'spectral_api_key': spectral_api_key})
+
+    response = client.request_batch(test_set_addresses)
+    test_set_with_features = pd.DataFrame(response)
+
+    testing_samples_scaled = sc.transform(test_set_with_features[training_cols])
+
+    model_1.eval()
+
+    # Inference using the trained model
+    with torch.inference_mode():
+        pol = model_1(torch.tensor(testing_samples_scaled).float().to(device)).squeeze().detach().cpu().numpy()
+
+    # Create a DataFrame with predictions
+    submission_dataframe = pd.DataFrame(testing_samples_scaled, index=test_set_with_features.index,
+                                        columns=test_set_with_features[training_cols].columns)
+    submission_dataframe['wallet_address'] = test_set_with_features['wallet_address']
+    submission_dataframe['pred_prob'] = pol
+
+    submission_dataframe['pred_label'] = (
+        submission_dataframe['pred_prob'].apply(lambda x: 1 if x > .6 else 0))
+
+    # Format the DataFrame for submission
+    non_feature_cols = ['wallet_address', 'pred_prob', 'pred_label']
+
+    # Rename feature columns for anonymity (optional)
+    for index, col in enumerate(submission_dataframe.columns):
+        if col not in non_feature_cols:
+            submission_dataframe.rename(columns={col: f'feature_{index + 1}'}, inplace=True)
+
+    # Order the columns for readability (optional)
+    cols_order_list = non_feature_cols + [col for col in submission_dataframe.columns if col not in non_feature_cols]
+    submission_dataframe = submission_dataframe[cols_order_list]
+
+    # Save the submission file
+    submission_dataframe.to_parquet('submissions/submission.parquet', index=False)
+
+    # Zane uncomment when ready to submit
+    # os.system("spectral-cli submit-inferences 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544 submissions/submission.parquet")
+    print('submitted!')
+if __name__ == '__main__':
+    create_simple_submission()

--- a/simple_submission.py
+++ b/simple_submission.py
@@ -245,11 +245,11 @@ def create_simple_submission():
 
     response = client.request_batch(test_set_addresses)
     test_set_with_features = pd.DataFrame(response)
-
+    print(f'Fetched {test_set_with_features.shape[1]} features for {test_set_with_features.shape[0]} addresses')
     testing_samples_scaled = sc.transform(test_set_with_features[training_cols])
 
+    print('Making predictions')
     model_1.eval()
-
     # Inference using the trained model
     with torch.inference_mode():
         pol = model_1(torch.tensor(testing_samples_scaled).float().to(device)).squeeze().detach().cpu().numpy()
@@ -278,6 +278,7 @@ def create_simple_submission():
     # Save the submission file
     submission_dataframe.to_parquet('submissions/submission.parquet', index=False)
 
+    print('Submitting predictions')
     # Zane uncomment when ready to submit
     # os.system("spectral-cli submit-inferences 0xFDC1BE05aD924e6Fc4Ab2c6443279fF7C0AB5544 submissions/submission.parquet")
     print('submitted!')


### PR DESCRIPTION
The create_baseline_submission function in baseline_submission.py allows modelers to download training data, train a simple model, download test data, and submit predictions without stepping through the entire starter kit. The readme has been updated with instructions on how to create a baseline submission. 

There is also updated functionality in the starter kit to automatically detect which operating system a user is running the notebook on. This is relevant when referencing paths for the Spectral CLI config file. 